### PR TITLE
Support perl down to 5.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 
 language: perl
 perl:
+  - "5.8"
   - "5.10"
   - "5.12"
   - "5.14"
@@ -21,13 +22,10 @@ env:
     - EXTENDED_TESTING=1
     - TEST_MYSQL_USER=root
     - TEST_MYSQL_PASS=
+    - COVERAGE="coveralls"
 
 before_install:
-  - cpanm -nq Devel::Cover::Report::Coveralls
-  - cpanm -nq EV Mojolicious AnyEvent
+  - eval $(curl https://travis-perl.github.io/init) --auto
 install:
-  - cpanm -nq --installdeps .
-script:
-  - perl Build.PL && ./Build && cover -test
-after_success:
-  - cover -report coveralls
+  - cpan-install --coverage --deps EV AnyEvent EV
+  - cpan-install Mojolicious || true # requires 5.10

--- a/Build.PL
+++ b/Build.PL
@@ -2,6 +2,6 @@
 use strict;
 use warnings;
 
-use 5.010001;
+use 5.008001;
 use Module::Build::Tiny 0.034;
 Build_PL();

--- a/META.json
+++ b/META.json
@@ -44,7 +44,7 @@
             "Scalar::Util" : "0",
             "Test::MockModule" : "0",
             "bignum" : "0",
-            "perl" : "5.010001"
+            "perl" : "5.008001"
          }
       },
       "test" : {

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.010001';
+requires 'perl', '5.008001';
 
 requires 'Export::Attrs';
 requires 'List::Util', '1.33';

--- a/t/AnyEvent.t
+++ b/t/AnyEvent.t
@@ -1,4 +1,4 @@
-use 5.010001;
+use 5.008001;
 use warnings;
 use strict;
 use utf8;

--- a/t/CORE.t
+++ b/t/CORE.t
@@ -1,4 +1,4 @@
-use 5.010001;
+use 5.008001;
 use warnings;
 use strict;
 use utf8;

--- a/t/EV.t
+++ b/t/EV.t
@@ -1,4 +1,4 @@
-use 5.010001;
+use 5.008001;
 use warnings;
 use strict;
 use utf8;

--- a/t/Mojolicious-EV.t
+++ b/t/Mojolicious-EV.t
@@ -1,4 +1,4 @@
-use 5.010001;
+use 5.008001;
 use warnings;
 use strict;
 use utf8;

--- a/t/Mojolicious.t
+++ b/t/Mojolicious.t
@@ -1,4 +1,4 @@
-use 5.010001;
+use 5.008001;
 use warnings;
 use strict;
 use utf8;

--- a/t/TimeHiRes.t
+++ b/t/TimeHiRes.t
@@ -1,4 +1,4 @@
-use 5.010001;
+use 5.008001;
 use warnings;
 use strict;
 use utf8;


### PR DESCRIPTION
This module is used by Devel::Cover::Report::Codecov, which would
otherwise work on 5.8.1.
  